### PR TITLE
Two improvements of the installation description

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ sudo apt-get update
 sudo apt-get upgrade
 ```
 
-We need to install redis, mongoDB and Nginx:
+We need to install redis, mongoDB, Nginx and Python:
 
 ```
-sudo apt-get install build-essential redis-server mongodb nginx
+sudo apt-get install build-essential redis-server mongodb nginx python
 ```
 
 Now you need install git and clone the openHAB Cloud repository to your
@@ -77,6 +77,15 @@ drwx------  2 ubuntu ubuntu 4096 Jun  4 12:34 .ssh
 ```
 
 
+Now we need to change into the openhabcloud directory and check if node is installed:
+
+```
+node --version
+```
+
+
+If you see the node version, you are fine to continue.
+
 To run openHAB Cloud you need to install the required software bundles/stacks:
 
 ```
@@ -90,15 +99,6 @@ and all the module dependencies from **package.json** will be resolved and neede
 
 
 
-Now we need to change into the openhabcloud directory and check if node is installed:
-
-```
-ls -al
-node --version
-```
-
-
-If you see the node version, you are fine to continue.
 
 
 


### PR DESCRIPTION
1. On a clean Ubuntu 16 system python is not installed, but it is necessary for npm
2. npm is installed as part of node.js. Therefore it is better to check first the correct installation of node.js and then execute npm

Signed-off-by: Martin Herbst <mail@mherbst.de>